### PR TITLE
Add a setting to configure checkpoint duration

### DIFF
--- a/src/main/resources/bullet_spark_defaults.yaml
+++ b/src/main/resources/bullet_spark_defaults.yaml
@@ -13,6 +13,7 @@ bullet.spark.metrics.enabled: false
 bullet.spark.filter.partition.parallel.mode.enabled: false
 bullet.spark.filter.partition.parallel.mode.parallelism: 4
 bullet.spark.filter.partition.parallel.mode.min.query.threshold: 10
+bullet.spark.checkpoint.duration.multiplier: 10
 
 ########################################################################################################################
 ######################################### Spark Streaming defaults #####################################

--- a/src/main/resources/bullet_spark_defaults.yaml
+++ b/src/main/resources/bullet_spark_defaults.yaml
@@ -13,7 +13,8 @@ bullet.spark.metrics.enabled: false
 bullet.spark.filter.partition.parallel.mode.enabled: false
 bullet.spark.filter.partition.parallel.mode.parallelism: 4
 bullet.spark.filter.partition.parallel.mode.min.query.threshold: 10
-bullet.spark.checkpoint.duration.multiplier: 10
+bullet.spark.query.union.checkpoint.duration.multiplier: 10
+bullet.spark.join.checkpoint.duration.multiplier: 10
 
 ########################################################################################################################
 ######################################### Spark Streaming defaults #####################################

--- a/src/main/scala/com/yahoo/bullet/spark/JoinStreaming.scala
+++ b/src/main/scala/com/yahoo/bullet/spark/JoinStreaming.scala
@@ -36,9 +36,9 @@ object JoinStreaming {
     val metrics = BulletSparkMetrics.getInstance(ssc, broadcastedConfig)
     val config = broadcastedConfig.value
     val duration = config.get(BulletSparkConfig.BATCH_DURATION_MS).asInstanceOf[Int]
-    val checkpointDurationMultiplier = config.get(BulletSparkConfig.CHECKPOINT_DURATION_MULTIPLIER).asInstanceOf[Int]
+    val durationMultiplier = config.get(BulletSparkConfig.JOIN_CHECKPOINT_DURATION_MULTIPLIER).asInstanceOf[Int]
     partialResultsStream.mapWithState(StateSpec.function(makeMapFunc(metrics, broadcastedConfig) _))
-      .checkpoint(Durations.milliseconds(checkpointDurationMultiplier * duration))
+      .checkpoint(Durations.milliseconds(durationMultiplier * duration))
   }
 
   private def makeMapFunc(metrics: BulletSparkMetrics, broadcastedConfig: Broadcast[BulletSparkConfig])

--- a/src/main/scala/com/yahoo/bullet/spark/QueryDataUnioning.scala
+++ b/src/main/scala/com/yahoo/bullet/spark/QueryDataUnioning.scala
@@ -51,9 +51,9 @@ object QueryDataUnioning {
     // Generate query stream including valid queries.
     val config = broadcastedConfig.value
     val duration = config.get(BulletSparkConfig.BATCH_DURATION_MS).asInstanceOf[Int]
-    val checkpointDurationMultiplier = config.get(BulletSparkConfig.CHECKPOINT_DURATION_MULTIPLIER).asInstanceOf[Int]
+    val durationMultiplier = config.get(BulletSparkConfig.QUERY_UNION_CHECKPOINT_DURATION_MULTIPLIER).asInstanceOf[Int]
     queryPairStream.updateStateByKey(updateFunc)
-      .checkpoint(Durations.milliseconds(checkpointDurationMultiplier * duration))
+      .checkpoint(Durations.milliseconds(durationMultiplier * duration))
   }
 
   private def updateFunc(queryList: Seq[BulletData], state: Option[BulletData]): Option[BulletData] = {

--- a/src/main/scala/com/yahoo/bullet/spark/utils/BulletSparkConfig.scala
+++ b/src/main/scala/com/yahoo/bullet/spark/utils/BulletSparkConfig.scala
@@ -28,6 +28,7 @@ object BulletSparkConfig {
   val FILTER_PARTITION_MODE_PARALLELISM = "bullet.spark.filter.partition.parallel.mode.parallelism"
   val FILTER_PARTITION_PARALLEL_MODE_MIN_QUERY_THRESHOLD =
     "bullet.spark.filter.partition.parallel.mode.min.query.threshold"
+  val CHECKPOINT_DURATION_MULTIPLIER = "bullet.spark.checkpoint.duration.multiplier"
 
   val SPARK_STREAMING_CONFIG_PREFIX = "spark."
   val DEFAULT_CONFIGURATION = "bullet_spark_defaults.yaml"
@@ -58,6 +59,7 @@ object BulletSparkConfig {
   private val DEFAULT_FILTER_PARTITION_PARALLEL_MODE_ENABLED = false
   private val DEFAULT_FILTER_PARTITION_MODE_PARALLELISM = 4
   private val DEFAULT_FILTER_PARTITION_PARALLEL_MODE_MIN_QUERY_THRESHOLD = 10
+  private val DEFAULT_CHECKPOINT_DURATION_MULTIPLIER = 10
 
   private val VALIDATOR = BulletConfig.getValidator
   VALIDATOR.define(QUERY_BLOCK_SIZE)
@@ -100,6 +102,10 @@ object BulletSparkConfig {
     .castTo(asJavaFunction(Validator.asInt))
   VALIDATOR.define(FILTER_PARTITION_PARALLEL_MODE_MIN_QUERY_THRESHOLD)
     .defaultTo(DEFAULT_FILTER_PARTITION_PARALLEL_MODE_MIN_QUERY_THRESHOLD)
+    .checkIf(asJavaPredicate(Validator.isPositiveInt))
+    .castTo(asJavaFunction(Validator.asInt))
+  VALIDATOR.define(CHECKPOINT_DURATION_MULTIPLIER)
+    .defaultTo(DEFAULT_CHECKPOINT_DURATION_MULTIPLIER)
     .checkIf(asJavaPredicate(Validator.isPositiveInt))
     .castTo(asJavaFunction(Validator.asInt))
 

--- a/src/main/scala/com/yahoo/bullet/spark/utils/BulletSparkConfig.scala
+++ b/src/main/scala/com/yahoo/bullet/spark/utils/BulletSparkConfig.scala
@@ -28,7 +28,8 @@ object BulletSparkConfig {
   val FILTER_PARTITION_MODE_PARALLELISM = "bullet.spark.filter.partition.parallel.mode.parallelism"
   val FILTER_PARTITION_PARALLEL_MODE_MIN_QUERY_THRESHOLD =
     "bullet.spark.filter.partition.parallel.mode.min.query.threshold"
-  val CHECKPOINT_DURATION_MULTIPLIER = "bullet.spark.checkpoint.duration.multiplier"
+  val QUERY_UNION_CHECKPOINT_DURATION_MULTIPLIER = "bullet.spark.query.union.checkpoint.duration.multiplier"
+  val JOIN_CHECKPOINT_DURATION_MULTIPLIER = "bullet.spark.join.checkpoint.duration.multiplier"
 
   val SPARK_STREAMING_CONFIG_PREFIX = "spark."
   val DEFAULT_CONFIGURATION = "bullet_spark_defaults.yaml"
@@ -59,7 +60,8 @@ object BulletSparkConfig {
   private val DEFAULT_FILTER_PARTITION_PARALLEL_MODE_ENABLED = false
   private val DEFAULT_FILTER_PARTITION_MODE_PARALLELISM = 4
   private val DEFAULT_FILTER_PARTITION_PARALLEL_MODE_MIN_QUERY_THRESHOLD = 10
-  private val DEFAULT_CHECKPOINT_DURATION_MULTIPLIER = 10
+  private val DEFAULT_QUERY_UNION_CHECKPOINT_DURATION_MULTIPLIER = 10
+  private val DEFAULT_JOIN_CHECKPOINT_DURATION_MULTIPLIER = 10
 
   private val VALIDATOR = BulletConfig.getValidator
   VALIDATOR.define(QUERY_BLOCK_SIZE)
@@ -104,8 +106,12 @@ object BulletSparkConfig {
     .defaultTo(DEFAULT_FILTER_PARTITION_PARALLEL_MODE_MIN_QUERY_THRESHOLD)
     .checkIf(asJavaPredicate(Validator.isPositiveInt))
     .castTo(asJavaFunction(Validator.asInt))
-  VALIDATOR.define(CHECKPOINT_DURATION_MULTIPLIER)
-    .defaultTo(DEFAULT_CHECKPOINT_DURATION_MULTIPLIER)
+  VALIDATOR.define(QUERY_UNION_CHECKPOINT_DURATION_MULTIPLIER)
+    .defaultTo(DEFAULT_QUERY_UNION_CHECKPOINT_DURATION_MULTIPLIER)
+    .checkIf(asJavaPredicate(Validator.isPositiveInt))
+    .castTo(asJavaFunction(Validator.asInt))
+  VALIDATOR.define(JOIN_CHECKPOINT_DURATION_MULTIPLIER)
+    .defaultTo(DEFAULT_JOIN_CHECKPOINT_DURATION_MULTIPLIER)
     .checkIf(asJavaPredicate(Validator.isPositiveInt))
     .castTo(asJavaFunction(Validator.asInt))
 

--- a/src/test/resources/test_config.yaml
+++ b/src/test/resources/test_config.yaml
@@ -14,4 +14,5 @@ spark.streaming.blockInterval": "1ms"
 spark.streaming.receiverRestartDelay": "1"
 bullet.spark.metrics.enabled: false
 bullet.spark.checkpoint.dir: "target/spark-test"
-bullet.spark.checkpoint.duration.multiplier: 1
+bullet.spark.query.union.checkpoint.duration.multiplier: 1
+bullet.spark.join.checkpoint.duration.multiplier: 1

--- a/src/test/resources/test_config.yaml
+++ b/src/test/resources/test_config.yaml
@@ -7,10 +7,11 @@ bullet.spark.data.producer.class.name: "com.yahoo.bullet.spark.MockDataProducer"
 bullet.spark.loop.pubsub.overrides:
   "name": "fake"
 
-bullet.spark.batch.duration.ms: 100
+bullet.spark.batch.duration.ms: 1000
 bullet.spark.data.producer.parallelism: 1
 spark.default.parallelism": "1"
 spark.streaming.blockInterval": "1ms"
 spark.streaming.receiverRestartDelay": "1"
 bullet.spark.metrics.enabled: false
 bullet.spark.checkpoint.dir: "target/spark-test"
+bullet.spark.checkpoint.duration.multiplier: 1

--- a/src/test/resources/test_config.yaml
+++ b/src/test/resources/test_config.yaml
@@ -7,7 +7,7 @@ bullet.spark.data.producer.class.name: "com.yahoo.bullet.spark.MockDataProducer"
 bullet.spark.loop.pubsub.overrides:
   "name": "fake"
 
-bullet.spark.batch.duration.ms: 10
+bullet.spark.batch.duration.ms: 100
 bullet.spark.data.producer.parallelism: 1
 spark.default.parallelism": "1"
 spark.streaming.blockInterval": "1ms"


### PR DESCRIPTION
So we can reduce the frequency of checkpoints to reduce disk writes by increasing bullet.spark.checkpoint.duration.multiplier.